### PR TITLE
Manual Selection and Overlap Fix

### DIFF
--- a/src/drawOnMap.js
+++ b/src/drawOnMap.js
@@ -38,7 +38,8 @@ export default class Artist extends BindingClass {
             source: 'customPoints',
             layout: {
                 'icon-image': 'mapPin',
-                'icon-size': .06
+                'icon-size': .06,
+                'icon-allow-overlap': true
             }
         });
     }
@@ -51,11 +52,14 @@ export default class Artist extends BindingClass {
         if (map.getSource("defaultPoints")) {
             map.removeSource("defaultPoints");
         }
+
         //Fetch the default points JSON
         const file = await fetch('../static/defaultPoints.geojson');
         const data = await file.json();
+
         //Inializes default points source
         map.addSource('defaultPoints', { type: 'geojson', data: data });
+
         //Creates the layer with default points as the source
         map.addLayer({
             id: 'points',
@@ -63,8 +67,16 @@ export default class Artist extends BindingClass {
             source: 'defaultPoints',
             layout: {
                 'icon-image': 'mapPin',
-                'icon-size': .06
+                'icon-size': .06,
+                'icon-allow-overlap': true
             }
         });
+    }
+
+    drawSinglePoint(p, map) {
+        let data = map.getSource("customPoints")._data;
+        console.log(data);
+        data.features.push(this.addFeature(p));
+        map.getSource("customPoints").setData(data);
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -96,7 +96,7 @@
                         <span>POINTS</span>
                         <div class="buttonGroup">
                             <button id="randomButton" class="groupedButton">SHUFFLE</button>
-                            <button class="groupedButton">CLICK</button>
+                            <button id="manualSelection" class="groupedButton">CLICK</button>
                             <button id="resetToDefault" class="groupedButton">MAP</button>
                         </div>
                     </p>


### PR DESCRIPTION
Middle button now toggles manual selection. Event listeners on the button toggle the adjacent buttons and turn on event listeners on the map. Cleaned up and commented, added icon overlap.